### PR TITLE
Commands: Add new command for squashing commits

### DIFF
--- a/src/data/primary-options.js
+++ b/src/data/primary-options.js
@@ -11,7 +11,8 @@ const options = [
   { value: 'clone', label: 'clone' },
   { value: 'ignore', label: 'ignore' },
   { value: 'rename', label: 'rename' },
-  { value: 'merge', label: 'merge' }
+  { value: 'merge', label: 'merge' },
+  { value: 'squash', label: 'squash' }
 ];
 
 export const primaryOptions = options.sort((x, y) => {

--- a/src/data/secondary-options.js
+++ b/src/data/secondary-options.js
@@ -222,4 +222,12 @@ export const secondaryOptions = {
       usage: 'git merge <branch-name>'
     }
   ],
+  squash: [
+    {
+      value: 'pr',
+      label: 'commits in pull request into single commit',
+      usage: 'git rebase -i <branch name>',
+      nb: 'Make sure that latest commits are fetched from upstream.\n\nFor example (assuming you have a remote named upstream):\n\ngit fetch upstream\ngit rebase -i upstream/master\n\nChange "pick" to "squash" for the commits you wish to squash and save.\n\ngit push origin <topic branch> --force-with-lease'
+    }
+  ]
 };


### PR DESCRIPTION
Related: #2 

Not entirely thrilled with the amount of supporting docs on this one and am open to advice on cutting it down.

`Squash` ➡️  `commits in pull request into single commit`

```
git rebase -i <branch name>
```

```
Make sure that latest commits are fetched from upstream.

git fetch upstream
git rebase -i upstream/master

Change "pick" to "squash" for the commits you wish to squash and save.

git push origin <topic branch> --force-with-lease
```