### PR TITLE
Fixed grammar on primary dropdown menu.

### DIFF
--- a/src/data/primary-options.js
+++ b/src/data/primary-options.js
@@ -14,7 +14,7 @@ const options = [
   { value: 'merge', label: 'merge' },
   { value: 'squash', label: 'squash' },
   { value: 'debug', label: 'debug' },
-  { value: 'recovery', label: 'recovery' },
+  { value: 'recover', label: 'recover' },
   { value: 'synchronize', label: 'synchronize' }
 ];
 

--- a/src/data/secondary-options.js
+++ b/src/data/secondary-options.js
@@ -325,7 +325,7 @@ export const secondaryOptions = {
     }
   ],
   
-  recovery: [
+  recover: [
     {
       value: 'dropped-commit',
       label: 'show hashes dangling commits after hard reset to previous commit',


### PR DESCRIPTION
Saw that "I want to..." should be followed by a verb and not a noun. Changed "recovery" to "recover".