### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build
+node_modules
+coverage


### PR DESCRIPTION
node_modules, build and coverage folders that might be generated in project are not needed when building docker image, as they are created during docker build. 
By ignoring them it is possible to speedup build and reduce size of the final image.