### PR TITLE
Corrected the git syntax for rebasing on local

### DIFF
--- a/src/data/secondary-options.js
+++ b/src/data/secondary-options.js
@@ -410,7 +410,7 @@ export const secondaryOptions = {
     {
       value: 'local-branch',
       label: 'a local branch into my working branch',
-      usage: 'git pull --rebase <branch name>',
+      usage: 'git rebase <branch name>',
       nb:
         'Rebase another local branch into working branch. Replace <branch name> with the branch you are pulling'
     },


### PR DESCRIPTION
Using git pull --rebase would pull from an origin branch. This is incorrect for rebasing from a local branch. Instead, the correct syntax should be git rebase <name-of-local-branch> 
https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase