### PR TITLE
Removed unnecessary "| less" to git diff command

### DIFF
--- a/src/data/secondary-options.js
+++ b/src/data/secondary-options.js
@@ -200,7 +200,7 @@ export const secondaryOptions = {
     {
       value: 'terminal',
       label: 'and output result in the terminal',
-      usage: 'git diff <sha1> <sha2> | less',
+      usage: 'git diff <sha1> <sha2>',
       nb: 'sha1 and sha2 are the sha hash of the commits you want to compare.'
     },
     {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38900226/82474060-deb3ed80-9aa0-11ea-907e-0e9f133ff5d4.png)

The command given is

`git diff <sha1> <sha2> | less`

But ` | less` is unnecessary, because `git` already invokes `less`.

To confirm this, run the following command:
`git diff <sha1> <sha2>`

If you run:
`sudo mv /usr/bin/less /usr/bin/lass`
 
And try the last command again, it won't work, because git won't be able to invoke `less`.

(Remember to move it back `sudo mv /usr/bin/lass /usr/bin/less`)